### PR TITLE
imx95: Change PLAT_NS_IMAGE_OFFSET to 0x90000000

### DIFF
--- a/plat/imx/imx95/include/platform_def.h
+++ b/plat/imx/imx95/include/platform_def.h
@@ -34,7 +34,7 @@
 
 /* non-secure uboot base */
 /* TODO */
-#define PLAT_NS_IMAGE_OFFSET		U(0x90200000)
+#define PLAT_NS_IMAGE_OFFSET		U(0x90000000)
 #define BL32_FDT_OVERLAY_ADDR           (PLAT_NS_IMAGE_OFFSET + 0x3000000)
 
 /* GICv4 base address */


### PR DESCRIPTION
This can also been seen as an issue report. Memory starts at 0x90000000 on imx95 and the device-tree by u-boot does not indicate any reserved region between 0x90000000 and 0x90200000, so this region can be used for normal-world side. Otherwise ATF/PSCI core boot-up prevents using addresses between 0x90000000-0x90200000 for the boot-up code.