### PR TITLE
imx93: trdc: fix header guard

### DIFF
--- a/include/drivers/nxp/trdc/imx_trdc.h
+++ b/include/drivers/nxp/trdc/imx_trdc.h
@@ -5,7 +5,7 @@
  */
 
 #ifndef IMX_TRDC_H
-#define IMX_XRDC_H
+#define IMX_TRDC_H
 
 #define MBC_BLK_ALL	U(255)
 #define MRC_REG_ALL	U(16)


### PR DESCRIPTION
Use correct header guard define:

| include/drivers/nxp/trdc/imx_trdc.h:7: error: header guard 'IMX_TRDC_H' followed by '#define' of a different macro [-Werror=header-guard]
|     7 | #ifndef IMX_TRDC_H
| include/drivers/nxp/trdc/imx_trdc.h:8: note: 'IMX_XRDC_H' is defined here; did you mean 'IMX_TRDC_H'?
|     8 | #define IMX_XRDC_H